### PR TITLE
[WIP] Can plugins set the ruby sdk?

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,12 @@ allprojects {
 intellij {
     version jetbrains.version
     pluginName "shadowenv"
-    type "IC"
+    type "RM"
     sameSinceUntilBuild false
     updateSinceUntilBuild false
     downloadSources true
-    plugins = ['java']
-    alternativeIdePath "/Users/tanner/Library/Application Support/JetBrains/Toolbox/apps/RubyMine/ch-0/192.6262.57/RubyMine.app/"
+//    plugins = ['ruby']
+    alternativeIdePath "/Applications/RubyMine.app/"
 }
 
 dependencies {

--- a/modules/products/rubymine/build.gradle
+++ b/modules/products/rubymine/build.gradle
@@ -4,11 +4,18 @@ plugins {
 }
 
 intellij {
-    version jetbrains.version
-    plugins jetbrains.rubymine
+//    version jetbrains.version
+//    plugins jetbrains.rubymine
+    type 'RM'
+    localPath '/Applications/RubyMine.app'
+}
+
+runIde {
+    ideaDirectory = '/Applications/RubyMine.app/Contents'
 }
 
 dependencies {
     compile project(":shadowenv-core")
     compile "org.jetbrains:annotations:16.0.3"
+    compile files("/Applications/RubyMine.app/Contents/plugins/ruby/lib/ruby.jar")
 }

--- a/modules/products/rubymine/src/main/java/com/shopify/shadowenv/products/rubymine/RubyMineRunConfigurationExtension.java
+++ b/modules/products/rubymine/src/main/java/com/shopify/shadowenv/products/rubymine/RubyMineRunConfigurationExtension.java
@@ -1,101 +1,101 @@
-package com.shopify.shadowenv.products.rubymine;
-
-import com.intellij.execution.*;
-import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.configurations.RunnerSettings;
-import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.projectRoots.ProjectJdkTable;
-import com.intellij.openapi.projectRoots.Sdk;
-import com.shopify.shadowenv.utils.Shadowenv;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.plugins.ruby.ruby.RModuleUtil;
-import org.jetbrains.plugins.ruby.ruby.run.configuration.AbstractRubyRunConfiguration;
-import org.jetbrains.plugins.ruby.ruby.run.configuration.RubyRunConfigurationExtension;
-
-import java.util.HashMap;
-import java.util.Map;
-
-public class RubyMineRunConfigurationExtension extends RubyRunConfigurationExtension {
-
-    @Override
-    protected void patchCommandLine(@NotNull AbstractRubyRunConfiguration configuration, @Nullable RunnerSettings runnerSettings, @NotNull GeneralCommandLine cmdLine, @NotNull String runnerId) throws ExecutionException {
-        Logger l = Logger.getInstance(RubyMineRunConfigurationExtension.class);
-
-        Map<String, String> gc = new GeneralCommandLine()
-                .withEnvironment(configuration.getEnvs())
-                .withParentEnvironmentType(
-                        configuration.isPassParentEnvs() ? GeneralCommandLine.ParentEnvironmentType.CONSOLE : GeneralCommandLine.ParentEnvironmentType.NONE
-                )
-                .getEffectiveEnvironment();
-
-        updateConfig(configuration, gc);
-        String version = gc.get("RUBY_VERSION");
-        if (version == null) {
-            l.error("could not find RUBY_VERSION in parsed output");
-            return;
-        }
-        l.warn("name: " + configuration.getModule().getName());
-        l.warn("version: " + configuration.getSdk().getVersionString());
-        // TODO(tb): we probably don't want to patch the command line like this. It'll run
-        // the correct ruby, but something else down the line seems to be resetting the env vars
-        cmdLine.setExePath(cmdLine.getExePath().replaceAll("[0-9]+\\.[0-9]+\\.[0-9]+", version));
-        cmdLine.withEnvironment(gc);
-    }
-
-    @Override
-    public boolean isApplicableFor(@NotNull AbstractRubyRunConfiguration configuration) {
-        return true;
-    }
-
-    @Override
-    public boolean isEnabledFor(@NotNull AbstractRubyRunConfiguration applicableConfiguration, @Nullable RunnerSettings runnerSettings) {
-        return true;
-    }
-
-    @Override
-    protected void extendCreatedConfiguration(@NotNull AbstractRubyRunConfiguration<?> configuration, @NotNull Location location) {
-        updateConfig(configuration, new HashMap<>());
-        super.extendCreatedConfiguration(configuration, location);
-    }
-
-    private void updateConfig(@NotNull AbstractRubyRunConfiguration<?> configuration, Map<String, String> env) {
-        Logger l = Logger.getInstance(RubyMineRunConfigurationExtension.class);
-        Map<String, String> m = new HashMap<>(env);
-        try {
-            Shadowenv.evaluate(configuration.getProject().getBasePath(), m);
-        } catch (Exception e) { l.error(e.getMessage()); }
-        env.clear();
-        env.putAll(m);
-
-        String curName = configuration.getSdk().getName();
-        String rv = m.get("RUBY_VERSION");
-        if (curName.contains(rv)) {
-            return;
-        }
-        l.info("found new ruby version: " + rv);
-        l.info("current sdk: " + curName);
-        Sdk sdk = findSdk("chruby: " + rv);
-        if (sdk == null) {
-            l.error("couldn't find sdk");
-            return;
-        }
-        RModuleUtil.getInstance().changeModuleSdk(sdk, configuration.getModule());
-        configuration.setShouldUseAlternativeSdk(true);
-        configuration.setAlternativeSdkName(sdk.getName());
-        l.info("set sdk to: " + configuration.getSdk().getName());
-    }
-
-    @Nullable
-    private Sdk findSdk(String name) {
-        Sdk sdk = null;
-        for (Sdk s : ProjectJdkTable.getInstance().getAllJdks()) {
-            if (!s.getName().contains(name)) {
-                continue;
-            }
-            sdk = s;
-            break;
-        }
-        return sdk;
-    }
-}
+//package com.shopify.shadowenv.products.rubymine;
+//
+//import com.intellij.execution.*;
+//import com.intellij.execution.configurations.GeneralCommandLine;
+//import com.intellij.execution.configurations.RunnerSettings;
+//import com.intellij.openapi.diagnostic.Logger;
+//import com.intellij.openapi.projectRoots.ProjectJdkTable;
+//import com.intellij.openapi.projectRoots.Sdk;
+//import com.shopify.shadowenv.utils.Shadowenv;
+//import org.jetbrains.annotations.NotNull;
+//import org.jetbrains.annotations.Nullable;
+//import org.jetbrains.plugins.ruby.ruby.RModuleUtil;
+//import org.jetbrains.plugins.ruby.ruby.run.configuration.AbstractRubyRunConfiguration;
+//import org.jetbrains.plugins.ruby.ruby.run.configuration.RubyRunConfigurationExtension;
+//
+//import java.util.HashMap;
+//import java.util.Map;
+//
+//public class RubyMineRunConfigurationExtension extends RubyRunConfigurationExtension {
+//
+//    @Override
+//    protected void patchCommandLine(@NotNull AbstractRubyRunConfiguration configuration, @Nullable RunnerSettings runnerSettings, @NotNull GeneralCommandLine cmdLine, @NotNull String runnerId) throws ExecutionException {
+//        Logger l = Logger.getInstance(RubyMineRunConfigurationExtension.class);
+//
+//        Map<String, String> gc = new GeneralCommandLine()
+//                .withEnvironment(configuration.getEnvs())
+//                .withParentEnvironmentType(
+//                        configuration.isPassParentEnvs() ? GeneralCommandLine.ParentEnvironmentType.CONSOLE : GeneralCommandLine.ParentEnvironmentType.NONE
+//                )
+//                .getEffectiveEnvironment();
+//
+//        updateConfig(configuration, gc);
+//        String version = gc.get("RUBY_VERSION");
+//        if (version == null) {
+//            l.error("could not find RUBY_VERSION in parsed output");
+//            return;
+//        }
+//        l.warn("name: " + configuration.getModule().getName());
+//        l.warn("version: " + configuration.getSdk().getVersionString());
+//        // TODO(tb): we probably don't want to patch the command line like this. It'll run
+//        // the correct ruby, but something else down the line seems to be resetting the env vars
+//        cmdLine.setExePath(cmdLine.getExePath().replaceAll("[0-9]+\\.[0-9]+\\.[0-9]+", version));
+//        cmdLine.withEnvironment(gc);
+//    }
+//
+//    @Override
+//    public boolean isApplicableFor(@NotNull AbstractRubyRunConfiguration configuration) {
+//        return true;
+//    }
+//
+//    @Override
+//    public boolean isEnabledFor(@NotNull AbstractRubyRunConfiguration applicableConfiguration, @Nullable RunnerSettings runnerSettings) {
+//        return true;
+//    }
+//
+//    @Override
+//    protected void extendCreatedConfiguration(@NotNull AbstractRubyRunConfiguration<?> configuration, @NotNull Location location) {
+//        updateConfig(configuration, new HashMap<>());
+//        super.extendCreatedConfiguration(configuration, location);
+//    }
+//
+//    private void updateConfig(@NotNull AbstractRubyRunConfiguration<?> configuration, Map<String, String> env) {
+//        Logger l = Logger.getInstance(RubyMineRunConfigurationExtension.class);
+//        Map<String, String> m = new HashMap<>(env);
+//        try {
+//            Shadowenv.evaluate(configuration.getProject().getBasePath(), m);
+//        } catch (Exception e) { l.error(e.getMessage()); }
+//        env.clear();
+//        env.putAll(m);
+//
+//        String curName = configuration.getSdk().getName();
+//        String rv = m.get("RUBY_VERSION");
+//        if (curName.contains(rv)) {
+//            return;
+//        }
+//        l.info("found new ruby version: " + rv);
+//        l.info("current sdk: " + curName);
+//        Sdk sdk = findSdk("chruby: " + rv);
+//        if (sdk == null) {
+//            l.error("couldn't find sdk");
+//            return;
+//        }
+//        RModuleUtil.getInstance().changeModuleSdk(sdk, configuration.getModule());
+//        configuration.setShouldUseAlternativeSdk(true);
+//        configuration.setAlternativeSdkName(sdk.getName());
+//        l.info("set sdk to: " + configuration.getSdk().getName());
+//    }
+//
+//    @Nullable
+//    private Sdk findSdk(String name) {
+//        Sdk sdk = null;
+//        for (Sdk s : ProjectJdkTable.getInstance().getAllJdks()) {
+//            if (!s.getName().contains(name)) {
+//                continue;
+//            }
+//            sdk = s;
+//            break;
+//        }
+//        return sdk;
+//    }
+//}

--- a/modules/products/rubymine/src/main/java/com/shopify/shadowenv/products/rubymine/RubyMineRunConfigurationExtension.java
+++ b/modules/products/rubymine/src/main/java/com/shopify/shadowenv/products/rubymine/RubyMineRunConfigurationExtension.java
@@ -68,7 +68,7 @@ public class RubyMineRunConfigurationExtension extends RubyRunConfigurationExten
         env.clear();
         env.putAll(m);
 
-        var curName = configuration.getSdk().getName();
+        String curName = configuration.getSdk().getName();
         String rv = m.get("RUBY_VERSION");
         if (curName.contains(rv)) {
             return;
@@ -89,7 +89,7 @@ public class RubyMineRunConfigurationExtension extends RubyRunConfigurationExten
     @Nullable
     private Sdk findSdk(String name) {
         Sdk sdk = null;
-        for (var s : ProjectJdkTable.getInstance().getAllJdks()) {
+        for (Sdk s : ProjectJdkTable.getInstance().getAllJdks()) {
             if (!s.getName().contains(name)) {
                 continue;
             }

--- a/modules/products/rubymine/src/main/java/com/shopify/shadowenv/products/rubymine/SetSdkOnLaunch.java
+++ b/modules/products/rubymine/src/main/java/com/shopify/shadowenv/products/rubymine/SetSdkOnLaunch.java
@@ -1,0 +1,38 @@
+package com.shopify.shadowenv.products.rubymine;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.startup.StartupActivity;
+import com.shopify.shadowenv.utils.Shadowenv;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.ruby.ruby.sdk.LocalRubySdkSystemAccessor;
+import org.jetbrains.plugins.ruby.ruby.sdk.RubySdkType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SetSdkOnLaunch implements StartupActivity {
+
+    private Logger logger;
+
+    public SetSdkOnLaunch() {
+        logger = Logger.getInstance(RubyMineRunConfigurationExtension.class);
+    }
+
+    @Override
+    public void runActivity(@NotNull Project project) {
+        // TODO: This looks like the right method
+        // Also while this API takes a path; it looks like RubyMine looks up existing SDKs before adding one.
+        Sdk sdk = SdkConfigurationUtil.createAndAddSDK("", RubySdkType.getInstance());
+
+        // TODO: Pretty sure this should _set_ the SDK but idk if it will work
+        ProjectRootManager.getInstance(project).setProjectSdk(sdk);
+
+        // TODO: Consider watching .shadowenv.d to 👀 when it changes
+        // TODO: Consider polling the Shadowenv class to watch for environment changes (e.g. if nix changes a path)
+    }
+}

--- a/modules/products/rubymine/src/main/java/com/shopify/shadowenv/products/rubymine/SetSdkOnLaunch.java
+++ b/modules/products/rubymine/src/main/java/com/shopify/shadowenv/products/rubymine/SetSdkOnLaunch.java
@@ -9,7 +9,6 @@ import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.startup.StartupActivity;
 import com.shopify.shadowenv.utils.Shadowenv;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.plugins.ruby.ruby.sdk.LocalRubySdkSystemAccessor;
 import org.jetbrains.plugins.ruby.ruby.sdk.RubySdkType;
 
 import java.util.HashMap;
@@ -20,11 +19,12 @@ public class SetSdkOnLaunch implements StartupActivity {
     private Logger logger;
 
     public SetSdkOnLaunch() {
-        logger = Logger.getInstance(RubyMineRunConfigurationExtension.class);
+        logger = Logger.getInstance(SetSdkOnLaunch.class);
     }
 
     @Override
     public void runActivity(@NotNull Project project) {
+        logger.error("What is going on");
         // TODO: This looks like the right method
         // Also while this API takes a path; it looks like RubyMine looks up existing SDKs before adding one.
         Sdk sdk = SdkConfigurationUtil.createAndAddSDK("", RubySdkType.getInstance());

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -41,7 +41,7 @@
 
   <depends optional="true" config-file="shadowenv-idea.xml">com.intellij.modules.lang</depends>
   <depends optional="true" config-file="shadowenv-pycharm.xml">com.intellij.modules.python</depends>
-  <depends optional="true" config-file="shadowenv-rubymine.xml">com.intellij.modules.ruby</depends>
+  <depends optional="false" config-file="shadowenv-rubymine.xml">com.intellij.modules.ruby</depends>
   <depends optional="true" config-file="shadowenv-goland.xml">org.jetbrains.plugins.go</depends>
 
 </idea-plugin>

--- a/src/main/resources/META-INF/shadowenv-rubymine.xml
+++ b/src/main/resources/META-INF/shadowenv-rubymine.xml
@@ -1,12 +1,9 @@
 <idea-plugin>
-    <extensions defaultExtensionNs="org.jetbrains.plugins.ruby">
-        <runConfigurationExtension implementation="com.shopify.shadowenv.products.rubymine.RubyMineRunConfigurationExtension" id="envfileRubyMine"/>
-    </extensions>
+<!--    <extensions defaultExtensionNs="org.jetbrains.plugins.ruby">-->
+<!--        <runConfigurationExtension implementation="com.shopify.shadowenv.products.rubymine.RubyMineRunConfigurationExtension" id="envfileRubyMine"/>-->
+<!--    </extensions>-->
     <extensions defaultExtensionNs="com.intellij">
-        <runConfigurationBeforeRunProviderDelegate implementation="com.shopify.shadowenv.products.rubymine.RubyMineRunconfigurationBeforeRunProviderDelegate" id="envfileRubyMineDelegate"/>
-        <backgroundPostStartupActivity implementation="com.shopify.shadowenv.products.rubymine.SetSdkOnLaunch" id="setSdkOnLaunchRubyMine" />
-    </extensions>
-    <extensions defaultExtensionNs="com.intellij.backgroundPostStartupActivity">
-        <
+<!--        <runConfigurationBeforeRunProviderDelegate implementation="com.shopify.shadowenv.products.rubymine.RubyMineRunconfigurationBeforeRunProviderDelegate" id="envfileRubyMineDelegate"/>-->
+        <postStartupActivity implementation="com.shopify.shadowenv.products.rubymine.SetSdkOnLaunch" id="setSdkOnLaunchRubyMine" />
     </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/shadowenv-rubymine.xml
+++ b/src/main/resources/META-INF/shadowenv-rubymine.xml
@@ -4,5 +4,9 @@
     </extensions>
     <extensions defaultExtensionNs="com.intellij">
         <runConfigurationBeforeRunProviderDelegate implementation="com.shopify.shadowenv.products.rubymine.RubyMineRunconfigurationBeforeRunProviderDelegate" id="envfileRubyMineDelegate"/>
+        <backgroundPostStartupActivity implementation="com.shopify.shadowenv.products.rubymine.SetSdkOnLaunch" id="setSdkOnLaunchRubyMine" />
+    </extensions>
+    <extensions defaultExtensionNs="com.intellij.backgroundPostStartupActivity">
+        <
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
A primary problem I have using Nix for setting the Ruby SDK is that nix changes the path to the Ruby executable often (the hash of the dependencies changes the entire path). My workflow at the moment is to kill RubyMine, run `mine .` from the shadowenv dir and then set the Ruby SDK manually through the UI.

Thought I could maybe speed this workflow up with an on-launch RubyMine thingo!

Never used gradle and the readme doesn't mention how best to build and test so this is very WIP but these APIs look promising (afaict RubyMine calls these APIs internally)